### PR TITLE
Support for canvas-based rendering

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,16 +1,53 @@
 // Defaults
 chrome.storage.sync.get(['isActivated'], ({ isActivated }) => {
-    if (typeof isActivated !== "boolean")
-        chrome.storage.sync.set({ isActivated: true })
+  if (typeof isActivated !== 'boolean') chrome.storage.sync.set({ isActivated: true })
 })
 
-// Insert into all existing tabs, 
+// Find all Google Docs tabs
+const findTabs = () =>
+  new Promise(resolve =>
+    chrome.tabs.query(
+      {
+        status: 'complete',
+        url: 'https://docs.google.com/document/*',
+      },
+      resolve
+    )
+  )
+
+// Changes the height of a window by a delta
+const resizeWindow = (windowId, delta) =>
+  new Promise(resolve =>
+    chrome.windows.get(windowId, win => {
+      chrome.windows.update(windowId, { height: win.height + delta })
+      resolve()
+    })
+  )
+
+// The most reliable I've found to trigger a re-render of the canvas element
+// is to change the size of the window. Dispatching events does nothing.
+// As such, we change the height by a single pixel back-and-forth
+let shouldExpand = false // Toggles whether to expand or contract the window
+const triggerCanvasRerender = async () => {
+  const tabs = await findTabs()
+  const windowIds = tabs.reduce((acc, inc) => {
+    acc[inc.windowId] = true
+    return acc
+  }, {})
+
+  await Promise.all(Object.keys(windowIds).map(windowId => resizeWindow(+windowId, shouldExpand ? 1 : -1)))
+  shouldExpand = !shouldExpand
+}
+
+// Insert into all existing tabs,
 // e.g. for when the user installs an extension but doesn't reload the page
-chrome.tabs.query({
-    status: 'complete',
-    url: 'https://docs.google.com/document/*'
-}, (tabs) =>
-    tabs.forEach((tab) => {
-        chrome.tabs.insertCSS(tab.id, { file: "override.css" })
-        chrome.tabs.executeScript(tab.id, { file: 'content.js', runAt: 'document_idle' })
-    }))
+findTabs().then(tabs =>
+  tabs.forEach(tab => {
+    chrome.tabs.insertCSS(tab.id, { file: 'override.css' })
+    chrome.tabs.executeScript(tab.id, { file: 'content.js', runAt: 'document_idle' })
+    chrome.tabs.executeScript(tab.id, { file: 'preload.js', runAt: 'document_start' })
+    triggerCanvasRerender()
+  })
+)
+
+chrome.storage.onChanged.addListener(triggerCanvasRerender)

--- a/background.js
+++ b/background.js
@@ -27,7 +27,6 @@ const resizeWindow = (windowId, delta) =>
 // The most reliable I've found to trigger a re-render of the canvas element
 // is to change the size of the window. Dispatching events does nothing.
 // As such, we change the height by a single pixel back-and-forth
-let shouldExpand = false // Toggles whether to expand or contract the window
 const triggerCanvasRerender = async () => {
   const tabs = await findTabs()
   const windowIds = tabs.reduce((acc, inc) => {
@@ -35,8 +34,12 @@ const triggerCanvasRerender = async () => {
     return acc
   }, {})
 
-  await Promise.all(Object.keys(windowIds).map(windowId => resizeWindow(+windowId, shouldExpand ? 1 : -1)))
-  shouldExpand = !shouldExpand
+  await Promise.all(
+    Object.keys(windowIds).map(async windowId => {
+      await resizeWindow(+windowId, -1)
+      await resizeWindow(+windowId, 1)
+    })
+  )
 }
 
 // Insert into all existing tabs,

--- a/content.js
+++ b/content.js
@@ -1,10 +1,14 @@
-const manageOverrideCss = (add) => {
-    const clazz = "google-docs-utility-override"
-    if (add && !document.body.classList.contains(clazz)) {
-        document.body.classList.add(clazz)
-    } else if (!add) {
-        document.body.classList.remove(clazz)
-    }
+// HTML-based Google Docs:
+//   Prior to May 2021, Google Docs' Kix Editor uses HTML elements to achieve styling.
+//   Tables are thus HTML tables and we style invisible tables via CSS
+
+const manageOverrideCss = add => {
+  const clazz = 'google-docs-utility-override' // duplicated in preload.js
+  if (add && !document.body.classList.contains(clazz)) {
+    document.body.classList.add(clazz)
+  } else if (!add) {
+    document.body.classList.remove(clazz)
+  }
 }
 
 chrome.storage.onChanged.addListener(({ isActivated }) => manageOverrideCss(isActivated.newValue))

--- a/manifest.json
+++ b/manifest.json
@@ -1,35 +1,36 @@
 {
-    "name": "View Google Docs Gridlines",
-    "short_name": "Google Docs Gridlines",
-    "version": "0.2",
-    "description": "View invisible table outlines as gridlines",
-    "manifest_version": 2,
-    "background": {
-        "scripts": ["background.js"]
+  "name": "View Google Docs Gridlines",
+  "short_name": "Google Docs Gridlines",
+  "version": "0.3",
+  "description": "View invisible table outlines as gridlines",
+  "manifest_version": 2,
+  "background": {
+    "scripts": ["background.js"]
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://docs.google.com/document/*"],
+      "js": ["content.js"],
+      "css": ["override.css"],
+      "run_at": "document_end"
     },
-    "content_scripts": [
-        {
-          "matches": [ "https://docs.google.com/document/*" ],
-          "js": [ "content.js" ],
-          "css": [ "override.css" ],
-          "run_at": "document_end"
-        }
-    ],
-    "icons": {
-        "128": "icon/chrome-web-store-icon.png"
+    {
+      "matches": ["https://docs.google.com/document/*"],
+      "js": ["preload.js"],
+      "run_at": "document_start"
+    }
+  ],
+  "icons": {
+    "128": "icon/chrome-web-store-icon.png"
+  },
+  "browser_action": {
+    "default_icon": {
+      "16": "icon/icon-activated-16.png",
+      "24": "icon/icon-activated-24.png",
+      "32": "icon/icon-activated-32.png"
     },
-    "browser_action": {
-        "default_icon": {
-            "16": "icon/icon-activated-16.png",
-            "24": "icon/icon-activated-24.png",
-            "32": "icon/icon-activated-32.png"
-        },
-        "default_title": "View Google Docs Gridlines",
-        "default_popup": "popup.html"
-    },
-    "permissions": [
-        "tabs",
-        "storage",
-        "https://docs.google.com/document/*"
-    ]
-  }
+    "default_title": "View Google Docs Gridlines",
+    "default_popup": "popup.html"
+  },
+  "permissions": ["tabs", "storage", "https://docs.google.com/document/*"]
+}

--- a/preload.js
+++ b/preload.js
@@ -1,6 +1,6 @@
 // Canvas-based Google Docs:
 //   After May 2021, Google Docs makes a slow transition from HTML rendering to canvas rendering
-//   We hijack, or monkey patch, key canvas methods to detect invisible lines and style them as dotted lines instead
+//   We monkey patch key canvas methods to detect invisible lines and style them as dotted lines instead
 
 const clazz = 'google-docs-utility-override' // duplicated in content.js
 

--- a/preload.js
+++ b/preload.js
@@ -1,0 +1,79 @@
+// Canvas-based Google Docs:
+//   After May 2021, Google Docs makes a slow transition from HTML rendering to canvas rendering
+//   We hijack, or monkey patch, key canvas methods to detect invisible lines and style them as dotted lines instead
+
+const clazz = 'google-docs-utility-override' // duplicated in content.js
+
+var elt = document.createElement('script')
+elt.innerHTML = `
+(() => { // don't leak
+
+  // Monkey patch the getContext method
+  const orig = window.HTMLCanvasElement.prototype.getContext
+  window.HTMLCanvasElement.prototype.getContext = function () {
+    try {
+      const context = orig.apply(this, arguments)
+      let cache = {} // don't redraw more than one overlapping line
+
+      // Called to before redrawing; forget about overlapping lines so as to redraw
+      const clearRect = context.clearRect
+      context.clearRect = function () {
+        clearRect.apply(context, arguments)
+        cache = {}
+      }
+
+      const rect = context.rect
+      context.rect = function () {
+        // i.e. if the lines are small and don't reach the end of the page and the plugin is enabled
+        if (context.lineWidth === 1 && arguments[0] > 5 && document.body.classList.contains('${clazz}')) { // 5 being the edge of the page
+          // Keep previous state
+          const lineDashOffset = context.lineDashOffset
+          const strokeStyle = context.strokeStyle
+          const lineDash = context.getLineDash()
+
+          // Set dotted line
+          context.setLineDash([4, 2])
+          context.strokeStyle = '#00000038'
+          context.beginPath()
+          const [x, y, w, h] = arguments
+          const combos = [
+            [[x, y], [x + w, y]],
+            [[x, y], [x, y + h]],
+            [[x + w, y], [x + w, y + h]],
+            [[x, y + h], [x + w, y + h]]
+          ]
+          combos.forEach(([a, b], i) => {
+            const s = 10 // sensitivity: some lines are very close to one another
+            const key = JSON.stringify([a.map(e => Math.round(e / s) * s), b.map(e => Math.round(e / s) * s)])
+            if (!cache[key]) { // don't draw overlapping lines
+              if (i <= 1){
+                // The top and left sides of rectangles are offsetted by 1
+                context.moveTo(...a.map(e => e - 1))
+                context.lineTo(...b.map(e => e - 1))
+              } else {
+                context.moveTo(...a)
+              context.lineTo(...b)
+              }
+              cache[key] = true
+            }
+          })
+          context.stroke()
+          context.closePath()
+
+          // Reset the context
+          context.setLineDash(lineDash)
+          context.lineDashOffset = lineDashOffset
+          context.strokeStyle = strokeStyle
+        }
+        rect.apply(context, arguments)
+      }
+
+      return context
+    } catch (e) {
+      console.error(e)
+    }
+  }
+
+})()
+`
+;(document.head || document.documentElement).appendChild(elt)

--- a/preload.js
+++ b/preload.js
@@ -44,6 +44,7 @@ elt.innerHTML = `
           ]
           combos.forEach(([a, b], i) => {
             const s = 10 // sensitivity: some lines are very close to one another
+            // TODO: find overlapping lines of different height
             const key = JSON.stringify([a.map(e => Math.round(e / s) * s), b.map(e => Math.round(e / s) * s)])
             if (!cache[key]) { // don't draw overlapping lines
               if (i <= 1){
@@ -52,7 +53,7 @@ elt.innerHTML = `
                 context.lineTo(...b.map(e => e - 1))
               } else {
                 context.moveTo(...a)
-              context.lineTo(...b)
+                context.lineTo(...b)
               }
               cache[key] = true
             }


### PR DESCRIPTION
Added support for Google's new canvas-based Kix editor for Google Docs.

> The Google Docs team is working on changing the rendering mechanism for Docs, migrating it from the current HTML-based rendering approach to a canvas-based rendering approach. The Docs team is planning on rolling out this new canvas-based approach over the next several months, growing the number of Docs using this canvas-based approach from ~1% of Google Docs in production (the current state), to 100% of Google Docs later this year.

Initial news release:
https://workspaceupdates.googleblog.com/2021/05/Google-Docs-Canvas-Based-Rendering-Update.html